### PR TITLE
Restructure workflows for Dependabot auto-merge with ImpressBot

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '5 4 * */3 0'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   auto-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,45 @@
+# Based on code from https://andre.arko.net/2022/05/15/automatic-dependabot-merges/
+
+name: "Merge updates"
+
+on:
+  workflow_run:
+    workflows:
+      - "Tests and Checks"
+    types:
+      - "completed"
+    branches:
+      - "dependabot/**"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge:
+    name: "Merge"
+    runs-on: "ubuntu-latest"
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.actor == 'dependabot[bot]'
+    steps:
+      - name: "Approve pull request"
+        uses: "juliangruber/approve-pull-request-action@v2"
+        with:
+          github-token: "${{ secrets.IMPRESSBOT_TOKEN }}"
+          number: "${{ github.event.workflow_run.pull_requests[0].number }}"
+
+      - name: "Merge pull request"
+        uses: "actions/github-script@v8"
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+            const pullRequest = context.payload.workflow_run.pull_requests[0]
+            const repository = context.repo
+            await github.rest.pulls.merge({
+              merge_method: "merge",
+              owner: repository.owner,
+              pull_number: pullRequest.number,
+              repo: repository.repo,
+            })

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,14 @@
-name: On pull request
+name: Tests and Checks
 
 on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 jobs:
 
@@ -58,34 +63,3 @@ jobs:
         run: npm test
         env:
           PHP_VERSION: ${{ matrix.php_version }}
-
-  dependabot:
-    needs:
-      - test
-    permissions: write-all
-    runs-on: ubuntu-latest
-    # Checking the actor will prevent your Action run failing on non-Dependabot
-    # PRs but also ensures that it only does work for Dependabot PRs.
-    if: ${{ github.actor == 'dependabot[bot]' }}
-    steps:
-      # This first step will fail if there's no metadata and so the approval
-      # will not occur.
-      - name: Dependabot metadata
-        id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v2.4.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      # Here the PR gets approved.
-      - name: Approve a PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Finally, this sets the PR to allow auto-merging for patch and minor
-      # updates if all checks pass
-      - name: Enable auto-merge for Dependabot PRs
-        # if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}      


### PR DESCRIPTION
## Summary
- split PR checks into a dedicated \Tests and Checks\ workflow
- add a separate \Merge updates\ workflow triggered by \workflow_run\ for successful Dependabot PR checks
- approve Dependabot PRs with \IMPRESSBOT_TOKEN\ and merge automatically after checks pass
- align autorelease workflow permissions with write access needs

## Reference
- patterned after https://github.com/impresscms-dev/generate-php-project-classes-list-file-action
