### PR TITLE
fix: use bot token to merge Dependabot workflow PRs

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "Merge pull request"
         uses: "actions/github-script@v8"
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: "${{ secrets.IMPRESSBOT_TOKEN }}"
           script: |
             const pullRequest = context.payload.workflow_run.pull_requests[0]
             const repository = context.repo


### PR DESCRIPTION
## Summary
This updates the Dependabot auto-merge workflow to use IMPRESSBOT_TOKEN for the merge API call instead of GITHUB_TOKEN.

## Why
GITHUB_TOKEN is blocked from merging pull requests that update files under .github/workflows/, which caused this failure:
- https://github.com/impresscms-dev/generate-phpdocs-with-evert-phpdoc-md-action/actions/runs/23629912636

## Change
- .github/workflows/dependabot.yml
  - ctions/github-script merge step now uses ${{ secrets.IMPRESSBOT_TOKEN }}

## Expected result
Dependabot PRs that include workflow file updates can be approved and merged by the auto-merge workflow without hitting the workflows permission error.